### PR TITLE
Fix variable names for Windows and Unix

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -31,8 +31,8 @@ MACRO( SET_OUTPUT_PATHS )
         # For Windows:
         # If we're an MSVC IDE Build, do nothing - otherwise treat same as unicies:
         #IF( NOT MSVC_IDE )
-            SET( EXECUTABLE_OUTPUT_DIRECTORY    ${CMAKE_BINARY_DIR}/bin )
-            SET( LIBRARY_OUTPUT_DIRECTORY       ${CMAKE_BINARY_DIR}/bin )
+            SET( EXECUTABLE_OUTPUT_PATH    ${CMAKE_BINARY_DIR}/bin )
+            SET( LIBRARY_OUTPUT_PATH       ${CMAKE_BINARY_DIR}/bin )
         #ENDIF()
 
     ELSEIF( UNIX )
@@ -40,8 +40,8 @@ MACRO( SET_OUTPUT_PATHS )
         # For linux and other unicies but not macosx, output binaries and libraries to
         # $BUILD_DIR/bin
 
-        SET( EXECUTABLE_OUTPUT_DIRECTORY    ${CMAKE_BINARY_DIR}/bin )
-        SET( LIBRARY_OUTPUT_DIRECTORY       ${CMAKE_BINARY_DIR}/bin )
+        SET( EXECUTABLE_OUTPUT_PATH    ${CMAKE_BINARY_DIR}/bin )
+        SET( LIBRARY_OUTPUT_PATH       ${CMAKE_BINARY_DIR}/bin )
 
     ELSE()
 


### PR DESCRIPTION
Fix the spelling of the output-parameters for cmake. Guess I didn't actually use this on Windows for a while :-)

On Unix, the r-path has hidden this problem...
